### PR TITLE
Change log of payload to be debug level

### DIFF
--- a/flask_kafka/consumer.py
+++ b/flask_kafka/consumer.py
@@ -53,7 +53,7 @@ class FlaskKafka():
         self.logger.info("starting consumer...registered signterm")
 
         for msg in self.consumer:
-            self.logger.info("TOPIC: {}, PAYLOAD: {}".format(msg.topic, msg.value))
+            self.logger.debug("TOPIC: {}, PAYLOAD: {}".format(msg.topic, msg.value))
             self._run_handlers(msg)
             # stop the consumer
             if self.interrupt_event.is_set():


### PR DESCRIPTION
The payload may be very verbose, or contain information you don't want to end up in logs so its nice to be able to filter this log out, while keeping the rest.